### PR TITLE
added primitive publish helper functions + mqtt getters

### DIFF
--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -485,7 +485,7 @@ void EspMQTTClient::connectToWifi()
 void EspMQTTClient::connectToMqttBroker()
 {
   if (mEnableSerialLogs)
-    Serial.printf("MQTT: Connecting to broker @%s ... ", mMqttServerIp);
+    Serial.printf("MQTT: Connecting to broker @%s with client name \"%s\"", mMqttServerIp, mMqttClientName);
 
   if (mMqttClient.connect(mMqttClientName, mMqttUsername, mMqttPassword, mMqttLastWillTopic, 0, mMqttLastWillRetain, mMqttLastWillMessage, mMqttCleanSession))
   {

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -298,6 +298,16 @@ bool EspMQTTClient::publish(const String &topic, const String &payload, bool ret
   return success;
 }
 
+bool EspMQTTClient::publish(const String &topic, char * value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, const char * value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
 bool EspMQTTClient::publish(const String &topic, bool value, bool retain)
 {
   return publish(topic, String(value), retain);

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -343,6 +343,11 @@ bool EspMQTTClient::publish(const String &topic, float value, bool retain)
  return publish(topic, String(value), retain);
 }
 
+bool EspMQTTClient::publish(const String &topic, short value, bool retain)
+{
+ return publish(topic, String(value), retain);
+}
+
 bool EspMQTTClient::subscribe(const String &topic, MessageReceivedCallback messageReceivedCallback)
 {
   // Check the possibility to add a new topic
@@ -419,6 +424,18 @@ bool EspMQTTClient::unsubscribe(const String &topic)
     Serial.println("MQTT! Topic cannot be found to unsubscribe, ignored.");
 
   return success;
+}
+
+const char * EspMQTTClient::getMqttClientName(void) {
+  return mMqttClientName;
+}
+
+const char * EspMQTTClient::getMqttServerIp(void) {
+  return mMqttServerIp;
+}
+
+const short EspMQTTClient::getMqttPort(void) {
+  return mMqttServerPort;
 }
 
 void EspMQTTClient::executeDelayed(const unsigned long delay, DelayedExecutionCallback callback)

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -298,6 +298,51 @@ bool EspMQTTClient::publish(const String &topic, const String &payload, bool ret
   return success;
 }
 
+bool EspMQTTClient::publish(const String &topic, bool value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, byte value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, char value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, word value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, unsigned int value, bool retain)
+{
+  return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, int value, bool retain) 
+{
+ return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, unsigned long value, bool retain)
+{
+ return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, long value, bool retain)
+{
+ return publish(topic, String(value), retain);
+}
+
+bool EspMQTTClient::publish(const String &topic, float value, bool retain)
+{
+ return publish(topic, String(value), retain);
+}
+
 bool EspMQTTClient::subscribe(const String &topic, MessageReceivedCallback messageReceivedCallback)
 {
   // Check the possibility to add a new topic

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -285,7 +285,7 @@ void EspMQTTClient::loop()
 
 bool EspMQTTClient::publish(const String &topic, const String &payload, bool retain)
 {
-  bool success = mMqttClient.publish_P(topic.c_str(), payload.c_str(), retain);
+  bool success = mMqttClient.publish(topic.c_str(), payload.c_str(), retain);
 
   if (mEnableSerialLogs) 
   {

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -285,7 +285,7 @@ void EspMQTTClient::loop()
 
 bool EspMQTTClient::publish(const String &topic, const String &payload, bool retain)
 {
-  bool success = mMqttClient.publish(topic.c_str(), payload.c_str(), retain);
+  bool success = mMqttClient.publish_P(topic.c_str(), payload.c_str(), retain);
 
   if (mEnableSerialLogs) 
   {

--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -172,9 +172,14 @@ public:
   bool publish(const String &topic, unsigned long value  , bool retain = false);
   bool publish(const String &topic, long value           , bool retain = false);
   bool publish(const String &topic, float value          , bool retain = false);
+  bool publish(const String &topic, short value          , bool retain = false);
 
   bool subscribe(const String &topic, MessageReceivedCallback messageReceivedCallback);
   bool unsubscribe(const String &topic);   //Unsubscribes from the topic, if it exists, and removes it from the CallbackList.
+
+  const char * getMqttClientName(void);
+  const char * getMqttServerIp(void);
+  const short getMqttPort(void);
 
   // Other
   void executeDelayed(const unsigned long delay, DelayedExecutionCallback callback);

--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -163,6 +163,8 @@ public:
   // MQTT related
   bool publish(const String &topic, const String &payload, bool retain = false);
 
+  bool publish(const String &topic, char * value         , bool retain = false);
+  bool publish(const String &topic, const char * value   , bool retain = false);
   bool publish(const String &topic, bool value           , bool retain = false);
   bool publish(const String &topic, byte value           , bool retain = false);
   bool publish(const String &topic, char value           , bool retain = false);

--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -162,6 +162,17 @@ public:
 
   // MQTT related
   bool publish(const String &topic, const String &payload, bool retain = false);
+
+  bool publish(const String &topic, bool value           , bool retain = false);
+  bool publish(const String &topic, byte value           , bool retain = false);
+  bool publish(const String &topic, char value           , bool retain = false);
+  bool publish(const String &topic, word value           , bool retain = false);
+  bool publish(const String &topic, unsigned int value   , bool retain = false);
+  bool publish(const String &topic, int value            , bool retain = false);
+  bool publish(const String &topic, unsigned long value  , bool retain = false);
+  bool publish(const String &topic, long value           , bool retain = false);
+  bool publish(const String &topic, float value          , bool retain = false);
+
   bool subscribe(const String &topic, MessageReceivedCallback messageReceivedCallback);
   bool unsubscribe(const String &topic);   //Unsubscribes from the topic, if it exists, and removes it from the CallbackList.
 


### PR DESCRIPTION
I've been using this library for some time now.
My PR includes:

I included primitive publish helper functions so that the user's of the lib does not need to cast the published topic everytime to a String(). This makes the code more readable.

Getters for MQTT client name, port and server ip (when creating derived classes these are useful; I need them anyway)