### PR TITLE
add setWifiCredentials method (Issue 73)

### DIFF
--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -499,6 +499,13 @@ void EspMQTTClient::setKeepAlive(uint16_t keepAliveSeconds)
   _mqttClient.setKeepAlive(keepAliveSeconds);
 }
 
+void EspMQTTClient::setWifiCredentials(const char* wifiSsid, const char* wifiPassword)
+{
+  _wifiSsid = wifiSsid;
+  _wifiPassword = wifiPassword;
+  _handleWiFi = true;
+}
+
 void EspMQTTClient::executeDelayed(const unsigned long delay, DelayedExecutionCallback callback)
 {
   DelayedExecutionRecord delayedExecutionRecord;

--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -146,6 +146,9 @@ public:
   void setKeepAlive(uint16_t keepAliveSeconds); // Change the keepalive interval (15 seconds by default)
   inline void setMqttClientName(const char* name) { _mqttClientName = name; }; // Allow to set client name manually (must be done in setup(), else it will not work.)
 
+  // Wifi related
+  void setWifiCredentials(const char* wifiSsid, const char* wifiPassword);
+
   // Other
   void executeDelayed(const unsigned long delay, DelayedExecutionCallback callback);
 


### PR DESCRIPTION
Added a method to set wifi credentials after initialization.

I believe this should fix https://github.com/plapointe6/EspMQTTClient/issues/73

My use case is that I don't have a wifi/pass until it is entered externally via an app.