### PR TITLE
fix: exception when mqttUsername is null

### DIFF
--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -572,7 +572,12 @@ bool EspMQTTClient::connectToMqttBroker()
   if (_mqttServerIp != nullptr && strlen(_mqttServerIp) > 0)
   {
     if (_enableSerialLogs)
-      Serial.printf("MQTT: Connecting to broker \"%s\" with client name \"%s\" and username \"%s\" ... (%fs) ", _mqttServerIp, _mqttClientName, _mqttUsername, millis()/1000.0);
+    {
+      if (_mqttUsername)
+        Serial.printf("MQTT: Connecting to broker \"%s\" with client name \"%s\" and username \"%s\" ... (%fs)", _mqttServerIp, _mqttClientName, _mqttUsername, millis()/1000.0);
+      else
+        Serial.printf("MQTT: Connecting to broker \"%s\" with client name \"%s\" ... (%fs)", _mqttServerIp, _mqttClientName, millis()/1000.0);
+    }
 
     // explicitly set the server/port here in case they were not provided in the constructor
     _mqttClient.setServer(_mqttServerIp, _mqttServerPort);


### PR DESCRIPTION
When the mqttUsername is unset (because there is no auth needed for the MQTT Server) the Serial.printf tried to display NULL which ended up in an exception and the ESP crashes. This happens in an endless loop.

I basically tried to binary search for the commit which introduced this bug and pinpointed d54a898 / #84. Looks like with the missing releases no one tried this commit without MQTT auth so far :D