### PR TITLE
Updated mqttTopicMatch to handle multiple wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You just need to provide your credentials and it will manage the following thing
 - Connecting to a MQTT broker.
 - Automatically detecting connection lost either from the WiFi client or the MQTT broker and it will retry a connection automatically.
 - Subscribing/unsubscribing to/from MQTT topics by a friendly callback system.
-- Supports a single occurrence of a '+' or '#' wildcard in subscriptions
+- Supports wildcards in subscriptions
 - Provide a callback handling to advise once everything is connected (Wifi and MQTT).
 - Provide a function to enable printing of useful debug information related to MQTT and Wifi connections.
 - Provide some other useful utilities for MQTT and Wifi management.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You just need to provide your credentials and it will manage the following thing
 - Connecting to a MQTT broker.
 - Automatically detecting connection lost either from the WiFi client or the MQTT broker and it will retry a connection automatically.
 - Subscribing/unsubscribing to/from MQTT topics by a friendly callback system.
-- Supports wildcards in subscriptions
+- Supports wildcards (`+`, `#`) in subscriptions
 - Provide a callback handling to advise once everything is connected (Wifi and MQTT).
 - Provide a function to enable printing of useful debug information related to MQTT and Wifi connections.
 - Provide some other useful utilities for MQTT and Wifi management.

--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -666,7 +666,7 @@ void EspMQTTClient::processDelayedExecutionRequests()
  * Matching MQTT topics, handling the eventual presence of wildcards character
  * It doesn't validate the correctness of the topic pattern.
  *
- * @param topic1 is the topic may contain wildcard(s)
+ * @param topic1 may contain wildcards (+, #)
  * @param topic2 must not contain wildcards
  * @return true on MQTT topic match, false otherwise
  */
@@ -677,8 +677,10 @@ bool EspMQTTClient::mqttTopicMatch(const String &topic1, const String &topic2)
   const char *topic2_p = topic2.begin();
   const char *topic2_end = topic2.end();
 
-  while (topic1_p < topic1_end && topic2_p < topic2_end) {
-    if (*topic1_p == '#'){
+  while (topic1_p < topic1_end && topic2_p < topic2_end)
+  {
+    if (*topic1_p == '#')
+    {
       // we assume '#' can be present only at the end of the topic pattern
       return true;
     }


### PR DESCRIPTION
This allows handling of subscriptions with multiple wildcards, for example:
```
+/error/#
```

Also more complex pattern can be handled with multiple occurrences of `+`.