### PR TITLE
Improve variable names

### DIFF
--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -161,7 +161,6 @@ void EspMQTTClient::enableLastWillMessage(const char* topic, const char* message
 
 void EspMQTTClient::loop()
 {
-  // WIFI handling
   bool wifiStateChanged = handleWiFi();
 
   // If there is a change in the wifi connection state, don't handle the mqtt connection state right away.
@@ -174,7 +173,6 @@ void EspMQTTClient::loop()
   if(mqttStateChanged)
     return;
 
-  // Procewss the delayed execution commands
   processDelayedExecutionRequests();
 }
 
@@ -297,7 +295,7 @@ bool EspMQTTClient::handleMQTT()
     _nextMqttConnectionAttemptMillis = millis() + _mqttReconnectionAttemptDelay;
   }
 
-  // It's time to  connect to the MQTT broker
+  // It's time to connect to the MQTT broker
   else if (isWifiConnected() && _nextMqttConnectionAttemptMillis > 0 && millis() >= _nextMqttConnectionAttemptMillis)
   {
     // Connect to MQTT broker

--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -43,7 +43,7 @@ private:
   bool _handleWiFi;
   bool _wifiConnected;
   bool _connectingToWifi;
-  unsigned long _lastWifiConnectiomAttemptMillis;
+  unsigned long _lastWifiConnectionAttemptMillis;
   unsigned long _nextWifiConnectionAttemptMillis;
   unsigned int _wifiReconnectionAttemptDelay;
   const char* _wifiSsid;
@@ -91,7 +91,7 @@ private:
 
   // General behaviour related
   ConnectionEstablishedCallback _connectionEstablishedCallback;
-  bool _enableSerialLogs;
+  bool _enableDebugMessages;
   bool _drasticResetOnConnectionFailures;
   unsigned int _connectionEstablishedCount; // Incremented before each _connectionEstablishedCallback call
 


### PR DESCRIPTION
In #105 and #108 there are some minor improvements to variable names which are worth to be added on their own.

Thanks to @autoantwort and @johndoe8967 for noticing them!

In regards to the `enableDebuggingMessages` method which currently sets a variable named `_enableSerialLogs`: I think it's better to name the internal variable the same as the method to keep the complexity lower.

I also noticed a typo in a comment which was describing the exact same thing as the method name so I just removed the comment rather than fixing the typo.