### PR TITLE
explicitly specify owner & version of dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,15 +1,18 @@
 {
-  "name":"EspMQTTClient",
-  "description":"A library that provides a wifi and MQTT connection to an ESP8266/ESP32",
-  "keywords":"mqtt,wifi,iot",
+  "name": "EspMQTTClient",
+  "description": "A library that provides a wifi and MQTT connection to an ESP8266/ESP32",
+  "keywords": [
+    "mqtt",
+    "wifi",
+    "iot"
+  ],
   "authors": [
     {
       "name": "Patrick Lapointe",
       "maintainer": true
     }
   ],
-  "repository":
-  {
+  "repository": {
     "type": "git",
     "url": "https://github.com/plapointe6/EspMQTTClient.git"
   },
@@ -18,7 +21,9 @@
   "platforms": ["espressif8266", "espressif32"],
   "dependencies": [
     {
+      "owner": "knolleary",
       "name": "PubSubClient",
+      "version": "^2.8.0",
       "platforms": ["espressif8266", "espressif32"]
     }
   ]


### PR DESCRIPTION
When working with some project of mine I got the following warning:

```plaintext
Library Manager: Installing PubSubClient
Library Manager: Warning! More than one package has been found by PubSubClient requirements:
Library Manager:  - knolleary/PubSubClient@2.8
Library Manager:  - drk/PubSubClient@2.8
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (shown above) to avoid name conflicts
```

I updated the library.json to specify the owner more explicitly. Also specified a semver version range.
And I fixed / formatted the JSON.