### PR TITLE
Put debug messages behind a define guard to reduce binary size

### DIFF
--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -29,6 +29,10 @@
 
 #endif
 
+// remove macro when compiling to remove all calls to Serial.print[ln]?
+// and reduce binary size
+#define ENABLE_DEBUG_MESSAGES
+
 void onConnectionEstablished(); // MUST be implemented in your sketch. Called once everythings is connected (Wifi, mqtt).
 
 typedef std::function<void()> ConnectionEstablishedCallback;


### PR DESCRIPTION
I've put all Serial.print(s) behind a define guard (ENABLE_DEBUG_MESSAGES). When enabled, the debug messages take up 1448 bytes which is ~2% of the variables and constants section when compiling.

Here's the output when compiling with `ENABLE_DEBUG_MESSAGES`:
```
. Variables and constants in RAM (global, static), used 30936 / 80192 bytes (38%)
║   SEGMENT  BYTES    DESCRIPTION
╠══ DATA     1500     initialized variables
╠══ RODATA   3044     constants       
╚══ BSS      26392    zeroed variables
. Instruction RAM (IRAM_ATTR, ICACHE_RAM_ATTR), used 60823 / 65536 bytes (92%)
║   SEGMENT  BYTES    DESCRIPTION
╠══ ICACHE   32768    reserved space for flash instruction cache
╚══ IRAM     28055    code in IRAM    
. Code in flash (default, ICACHE_FLASH_ATTR), used 315464 / 1048576 bytes (30%)
║   SEGMENT  BYTES    DESCRIPTION
╚══ IROM     315464   code in flash   
```

Here's the output when compiling without `ENABLE_DEBUG_MESSAGES`:
```
. Variables and constants in RAM (global, static), used 29480 / 80192 bytes (36%)
║   SEGMENT  BYTES    DESCRIPTION
╠══ DATA     1500     initialized variables
╠══ RODATA   1596     constants       
╚══ BSS      26384    zeroed variables
. Instruction RAM (IRAM_ATTR, ICACHE_RAM_ATTR), used 60823 / 65536 bytes (92%)
║   SEGMENT  BYTES    DESCRIPTION
╠══ ICACHE   32768    reserved space for flash instruction cache
╚══ IRAM     28055    code in IRAM    
. Code in flash (default, ICACHE_FLASH_ATTR), used 314136 / 1048576 bytes (29%)
║   SEGMENT  BYTES    DESCRIPTION
╚══ IROM     314136   code in flash   
```

NOTE: These logs are valid when compiling for the ESP8266 platform. In other models the percentages may differ.
NOTE: These logs were generated when compiling the SimpleMQTTClient example.