### PR TITLE
Add missing WiFi.h #include directive

### DIFF
--- a/src/EspMQTTClient.h
+++ b/src/EspMQTTClient.h
@@ -19,6 +19,7 @@
 
 #else // for ESP32
 
+  #include <WiFi.h>
   #include <WiFiClient.h>
   #include <WebServer.h>
   #include <ESPmDNS.h>


### PR DESCRIPTION
The "**EspMQTTClient**" library references objects declared by the [`WiFi.h` header](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFi.h) in the ["**esp32**" boards platform](https://github.com/espressif/arduino-esp32)'s bundled "**WiFi**" library.

Previously, the "**EspMQTTClient**" library relied on its [`#include` directive](https://github.com/plapointe6/EspMQTTClient/blob/ecb7151b1719798034019f7fd12c2277c4707470/src/ESP32HTTPUpdateServer.h#L8) for the `WebServer.h` header of the "[**WiFiServer**](https://github.com/espressif/arduino-esp32/tree/master/libraries/WebServer)" library providing an `#include` directive for the `WiFi.h` header:

https://github.com/espressif/arduino-esp32/blob/2.0.17/libraries/WebServer/src/WebServer.h#L29

This fragile code was broken by changes (https://github.com/espressif/arduino-esp32/commit/f2026f1e345970801084821d6e5f8f95a11fba47) made in the version of the "WiFiServer" library bundled with the 3.0.0 release of the "esp32" boards platform:

```diff
diff --git a/libraries/WebServer/src/WebServer.h b/libraries/WebServer/src/WebServer.h
index d668c4e70e7..2434855b6eb 100644
--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -26,8 +26,8 @@
 
 #include <functional>
 #include <memory>
-#include <WiFi.h>
-#include <FS.h>
+#include "FS.h"
+#include "Network.h"
 #include "HTTP_Method.h"
 #include "Uri.h"
```

causing the library to no longer compile for ESP32-based boards:

```text
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp: In member function 'bool EspMQTTClient::handleWiFi()': c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:187:5: error: 'WiFi' was not declared in this scope
  187 |     WiFi.disconnect(true);
      |     ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:194:27: error: 'WiFi' was not declared in this scope
  194 |   bool isWifiConnected = (WiFi.status() == WL_CONNECTED);
      |                           ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:194:44: error: 'WL_CONNECTED' was not declared in this scope; did you mean 'MQTT_CONNECTED'?
  194 |   bool isWifiConnected = (WiFi.status() == WL_CONNECTED);
      |                                            ^~~~~~~~~~~~
      |                                            MQTT_CONNECTED
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:215:27: error: 'WL_CONNECT_FAILED' was not declared in this scope; did you mean 'MQTT_CONNECT_FAILED'?
  215 |       if(WiFi.status() == WL_CONNECT_FAILED || millis() - _lastWifiConnectiomAttemptMillis >= _wifiReconnectionAttemptDelay)
      |                           ^~~~~~~~~~~~~~~~~
      |                           MQTT_CONNECT_FAILED
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp: In member function 'bool EspMQTTClient::handleMQTT()':
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:325:9: error: 'WiFi' was not declared in this scope
  325 |         WiFi.disconnect(true);
      |         ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp: In member function 'void EspMQTTClient::onWiFiConnectionEstablished()':
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:362:75: error: 'WiFi' was not declared in this scope
  362 |       Serial.printf("WiFi: Connected (%fs), ip : %s \n", millis()/1000.0, WiFi.localIP().toString().c_str());
      |                                                                           ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp: In member function 'void EspMQTTClient::onWiFiConnectionLost()':
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:388:5: error: 'WiFi' was not declared in this scope
  388 |     WiFi.disconnect(true);
      |     ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp: In member function 'void EspMQTTClient::connectToWifi()':
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:555:3: error: 'WiFi' was not declared in this scope
  555 |   WiFi.mode(WIFI_STA);
      |   ^~~~
c:\Users\per\Documents\Arduino\libraries\EspMQTTClient\src\EspMQTTClient.cpp:555:13: error: 'WIFI_STA' was not declared in this scope; did you mean 'WIFI_IF_STA'?
  555 |   WiFi.mode(WIFI_STA);
      |             ^~~~~~~~
      |             WIFI_IF_STA
```

The bug is solved by adding an `#include` directive for the `WiFi.h` header the "**EspMQTTClient**" library depends on.

---

Fixes https://github.com/plapointe6/EspMQTTClient/issues/142
Fixes https://github.com/plapointe6/EspMQTTClient/issues/140

Originally reported at https://forum.arduino.cc/t/broken-dependencies/1266624