### PR TITLE
Fixed hostname on ESP32

### DIFF
--- a/src/EspMQTTClient.cpp
+++ b/src/EspMQTTClient.cpp
@@ -556,12 +556,12 @@ void EspMQTTClient::executeDelayed(const unsigned long delay, DelayedExecutionCa
 // Initiate a Wifi connection (non-blocking)
 void EspMQTTClient::connectToWifi()
 {
-  WiFi.mode(WIFI_STA);
   #ifdef ESP32
     WiFi.setHostname(_mqttClientName);
   #else
     WiFi.hostname(_mqttClientName);
   #endif
+  WiFi.mode(WIFI_STA);
   WiFi.begin(_wifiSsid, _wifiPassword);
 
   if (_enableDebugMessages)


### PR DESCRIPTION
This commit fixes the hostname not getting applied on ESP32 since `WiFi.mode()` was called before setting the hostname.

## Explanation
Taking a look at the WiFi library, 
you can see [setHostname](https://github.com/espressif/arduino-esp32/blob/5e19e086c43d0fa5e5a596497ff8f11a0a43f6c2/libraries/WiFi/src/WiFiGeneric.cpp#L901) method calls [set_esp_netif_hostname](https://github.com/espressif/arduino-esp32/blob/5e19e086c43d0fa5e5a596497ff8f11a0a43f6c2/libraries/WiFi/src/WiFiGeneric.cpp#L292) which sets the `default_hostname` variable with the provided hostname.
This variable is read only by [get_esp_netif_hostname](https://github.com/espressif/arduino-esp32/blob/5e19e086c43d0fa5e5a596497ff8f11a0a43f6c2/libraries/WiFi/src/WiFiGeneric.cpp#L284) which gets called in [mode](https://github.com/espressif/arduino-esp32/blob/5e19e086c43d0fa5e5a596497ff8f11a0a43f6c2/libraries/WiFi/src/WiFiGeneric.cpp#L1249) and only when the mode is changed to `WIFI_MODE_STA` [ref](https://github.com/espressif/arduino-esp32/blob/77065bffb2c57704ee46ad0a43270e50860814f5/libraries/WiFi/src/WiFiGeneric.cpp#L1121)

## **_TL;DR_**
1. Call `WiFi.setHostname()` to set internal variable `default_hostname` with desired hostname.
2. Call `WiFi.mode()` with parameter `WIFI_STA` which will apply the hostname.

Tested and working on ESP32 (Arduino-ESP32 v2.0.17) and no breaking changes found on ESP8266.